### PR TITLE
Restore Remote object context manager support

### DIFF
--- a/samsungctl/__main__.py
+++ b/samsungctl/__main__.py
@@ -98,16 +98,15 @@ def main():
         return
 
     try:
-        remote = Remote(config)
+        with Remote(config) as remote:
+            for key in args.key:
+                remote.control(key)
 
-        for key in args.key:
-            remote.control(key)
-
-        if args.interactive:
-            logging.getLogger().setLevel(logging.ERROR)
-            interactive.run(remote)
-        elif len(args.key) == 0:
-            logging.warning("Warning: No keys specified.")
+            if args.interactive:
+                logging.getLogger().setLevel(logging.ERROR)
+                interactive.run(remote)
+            elif len(args.key) == 0:
+                logging.warning("Warning: No keys specified.")
     except exceptions.ConnectionClosed:
         logging.error("Error: Connection closed!")
     except exceptions.AccessDenied:

--- a/samsungctl/remote.py
+++ b/samsungctl/remote.py
@@ -11,6 +11,12 @@ class Remote:
         else:
             raise exceptions.UnknownMethod()
 
+    def __enter__(self):
+        return self.remote.__enter__()
+
+    def __exit__(self, type, value, traceback):
+        self.remote.__exit__(type, value, traceback)
+
     def close(self):
         return self.remote.close()
 


### PR DESCRIPTION
Seems like #19 broke the context manager (`with` statements / `__enter__` + `__exit__`) support for Remote objects. This PR restores the support and uses the `with` statement again in `__main__.py`.

@nunofgs @kylerw Could you test that the websocket feature still works with this patch?