### PR TITLE
Import curses only on interactive mode

### DIFF
--- a/samsungctl/__main__.py
+++ b/samsungctl/__main__.py
@@ -8,7 +8,6 @@ import socket
 from . import __doc__ as doc
 from . import __title__ as title
 from . import __version__ as version
-from . import interactive
 from . import exceptions
 from . import Remote
 
@@ -104,6 +103,7 @@ def main():
 
             if args.interactive:
                 logging.getLogger().setLevel(logging.ERROR)
+                from . import interactive
                 interactive.run(remote)
             elif len(args.key) == 0:
                 logging.warning("Warning: No keys specified.")


### PR DESCRIPTION
This make curses library optional and only required for the interactive mode.