### PR TITLE
Use cross-platform config file paths

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,8 +84,9 @@ arguments:
     E.g. samsungctl --host 192.168.0.10 --name myremote KEY_VOLDOWN
 
 The settings can be loaded from a configuration file. The file is searched from
-``$XDG_CONFIG_HOME/samsungctl.conf``, ``~/.config/samsungctl.conf``, and
-``/etc/samsungctl.conf`` in this order. A simple default configuration is
+a user specific path (usually ``~/.config/samsungctl.conf``) and if that is not
+found then from a system-wide path (usually
+``/etc/xdg/samsungctl/samsungctl.conf``). A simple default configuration is
 bundled with the source as `samsungctl.conf <samsungctl.conf>`_.
 
 Library usage

--- a/samsungctl/__main__.py
+++ b/samsungctl/__main__.py
@@ -1,3 +1,4 @@
+import appdirs
 import argparse
 import collections
 import json
@@ -23,12 +24,8 @@ def _read_config():
     file_loaded = False
     directories = []
 
-    xdg_config = os.getenv("XDG_CONFIG_HOME")
-    if xdg_config:
-        directories.append(xdg_config)
-
-    directories.append(os.path.join(os.getenv("HOME"), ".config"))
-    directories.append("/etc")
+    directories.append(appdirs.user_config_dir())
+    directories.append(appdirs.site_config_dir(title))
 
     for directory in directories:
         try:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
         "console_scripts": ["samsungctl=samsungctl.__main__:main"]
     },
     packages=["samsungctl"],
-    install_requires=[],
+    install_requires=["appdirs"],
     extras_require={
         "websocket": ["websocket-client"],
         "interactive_ui": ["curses"],


### PR DESCRIPTION
Note that this will move '/etc/samsungctl.conf' to '/etc/xdg/samsungctl/samsungctl.conf'. The user config file should remain in '~/.config/samsungctl.conf'.