### PR TITLE
Add timeout support for websocket connections

### DIFF
--- a/samsungctl/remote_websocket.py
+++ b/samsungctl/remote_websocket.py
@@ -18,9 +18,8 @@ class RemoteWebsocket():
         URL_FORMAT = "ws://{}:{}/api/v2/channels/samsung.remote.control?name={}"
 
         """Make a new connection."""
-        self.connection = websocket.WebSocket()
-        self.connection.connect(URL_FORMAT.format(config["host"], config["port"],
-                                                  self._serialize_string(config["name"])))
+        self.connection = websocket.create_connection(URL_FORMAT.format(config["host"], config["port"],
+                                                  self._serialize_string(config["name"])), config["timeout"])
 
         self._read_response()
 


### PR DESCRIPTION
This PR allows passing the timeout configuration to a websocket connection. 

This vastly improves the way the [Home Assistant](https://home-assistant.io/components/media_player.samsungtv/) samsung plugin detects that the TV is off, because it will now timeout properly and report the TV as unreachable.