### PR TITLE
Bind KEY_EXIT to q in interactive mode

### DIFF
--- a/samsungctl/interactive.py
+++ b/samsungctl/interactive.py
@@ -10,6 +10,7 @@ _mappings = [
     ["KEY_NPAGE",     "KEY_CHDOWN",        "Page Down", "P Down"],
     ["\n",            "KEY_ENTER",         "Enter",     "Enter"],
     ["KEY_BACKSPACE", "KEY_RETURN",        "Backspace", "Return"],
+    ["q",             "KEY_EXIT",          "Q",         "Exit"],
     ["h",             "KEY_CONTENTS",      "H",         "Smart Hub"],
     ["l",             "KEY_CH_LIST",       "L",         "Channel List"],
     ["m",             "KEY_MENU",          "M",         "Menu"],


### PR DESCRIPTION
I'm using OpenELEC / LibreELEC with multiple Samsung TVs and they use `KEY_EXIT` to navigate back menus in Kodi. I tested `stdscr.notimeout(True)` on the top of `_control()` function, but that didn't bring any effect. Decided to use this hacky solution of `ESCDELAY` environment variable set to zero, to not introduce 1000 milliseconds (per `curses(3)` manual page) delay while pressing Escape key.