### PR TITLE
Report if TV is on

### DIFF
--- a/samsungctl/remote.py
+++ b/samsungctl/remote.py
@@ -22,3 +22,6 @@ class Remote:
 
     def control(self, key):
         return self.remote.control(key)
+
+    def is_tv_on(self):
+        return self.remote.is_tv_on()

--- a/samsungctl/remote_legacy.py
+++ b/samsungctl/remote_legacy.py
@@ -58,6 +58,18 @@ class RemoteLegacy():
 
     _key_interval = 0.2
 
+    def is_tv_on(self):
+        try:
+            # Send an empty key to see if we are still connected
+            self.control('KEY')
+        except (exceptions.UnhandledResponse,
+                exceptions.AccessDenied, BrokenPipeError):
+            # We got a response so it's on.
+            # BrokenPipe can occur when the commands is sent to fast
+            return True
+        except (exceptions.ConnectionClosed, OSError):
+            return False
+
     def _read_response(self, first_time=False):
         header = self.connection.recv(3)
         tv_name_len = int.from_bytes(header[1:3],


### PR DESCRIPTION
This new method "is_tv_on()" report the status of the TV.
This aim at avoiding sending a dummy key for TV using websocket. Doing so can wake TV up if send during an update, or during an update status check.

This was happening for example in Home-Assistant, the key command 'KEY' was send via websocket, randomly waking TV up.

With the new method, the availability of the REST endpoint is checked (http://URL:PORT/api/v2/). It will still report the TV as being ON during update refresh, but won't turn it ON.


https://github.com/home-assistant/home-assistant/pull/11179