### PR TITLE
Adds more keys.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.egg-info/
 *.pyc
 *.swp
+.idea

--- a/samsungctl/interactive.py
+++ b/samsungctl/interactive.py
@@ -37,10 +37,40 @@ _mappings = [
     ["7",             "KEY_7",             "7",         "7"],
     ["8",             "KEY_8",             "8",         "8"],
     ["9",             "KEY_9",             "9",         "9"],
-    ["KEY_F(1)",      "KEY_DTV",           "F1",        "TV Source"],
+    ["KEY_F(1)",      "KEY_TV",            "F1",        "TV Source"],
     ["KEY_F(2)",      "KEY_HDMI",          "F2",        "HDMI Source"],
+    ["KEY_F(3)",      "KEY_DVI",           "F3",        "DVI Source"],
+    ["KEY_F(4)",      "KEY_DVR",           "F4",        "DVR Source"],
+    ["KEY_F(5)",      "KEY_DTV",           "F5",        "Digital TV Source"],
+    ["KEY_F(6)",      "KEY_ANTENA",        "F6",        "Analog TV Source"],
+    ["KEY_F(7)",      "KEY_FM_RADIO",      "F7",        "FM Radio Source"],
+    ["KEY_F(9)",      "KEY_HDMI1",         "F9",        "HDMI 1 Source"],
+    ["KEY_F(10)",     "KEY_HDMI2",         "F10",       "HDMI 2 Source"],
+    ["KEY_F(11)",     "KEY_HDMI3",         "F11",       "HDMI 3 Source"],
+    ["KEY_F(12)",     "KEY_HDMI4",         "F12",       "HDMI 4 Source"],
+    ["KEY_F(25)",     "KEY_AV1",           "CTRL+F1",   "AV 1 Source"],
+    ["KEY_F(26)",     "KEY_AV2",           "CTRL+F2",   "AV 2 Source"],
+    ["KEY_F(27)",     "KEY_AV3",           "CTRL+F3",   "AV 3 Source"],
+    ["KEY_F(29)",     "KEY_SVIDEO1",       "CTRL+F5",   "S Video 1 Source"],
+    ["KEY_F(30)",     "KEY_SVIDEO2",       "CTRL+F6",   "S Video 2 Source"],
+    ["KEY_F(31)",     "KEY_SVIDEO3",       "CTRL+F7",   "S Video 3 Source"],
+    ["KEY_F(33)",     "KEY_COMPONENT1",    "CTRL+F9",   "Component 1 Source"],
+    ["KEY_F(34)",     "KEY_COMPONENT2",    "CTRL+F10",  "Component 2 Source"],
 ]
-
+'''
+ctrl + functions
+f1 25
+f2 26
+f3 27
+f4 28
+f5 29
+f6 30
+f7 31
+f8 32
+f9 33
+f10 34
+f11 35 
+f12 36'''
 
 def run(remote):
     """Run interactive remote control application."""

--- a/samsungctl/key_mappings.py
+++ b/samsungctl/key_mappings.py
@@ -1,0 +1,310 @@
+
+
+class SendButtonCls(object):
+
+    def __init__(self, key, group, description):
+        self.key = key
+        self.group = group
+        self.description = description
+
+    def __call__(self, remote):
+        remote.control(self.key)
+
+    def __str__(self):
+        return '        {0}: {1}'.format(self.description, self.key)
+
+
+KEY_MAPPINGS = (
+    ('Power Keys ', (
+        ('Power OFF',                        'KEY_POWEROFF'),
+        ('Power On',                         'KEY_POWERON'),
+        ('Power Toggle',                     'KEY_POWER')
+    )),
+    ('Input Keys ', (
+        ('Source',                           'KEY_SOURCE'),
+        ('Component 1',                      'KEY_COMPONENT1'),
+        ('Component 2',                      'KEY_COMPONENT2'),
+        ('AV 1',                             'KEY_AV1'),
+        ('AV 2',                             'KEY_AV2'),
+        ('AV 3',                             'KEY_AV3'),
+        ('S Video 1',                        'KEY_SVIDEO1'),
+        ('S Video 2',                        'KEY_SVIDEO2'),
+        ('S Video 3',                        'KEY_SVIDEO3'),
+        ('HDMI',                             'KEY_HDMI'),
+        ('HDMI 1',                           'KEY_HDMI1'),
+        ('HDMI 2',                           'KEY_HDMI2'),
+        ('HDMI 3',                           'KEY_HDMI3'),
+        ('HDMI 4',                           'KEY_HDMI4'),
+        ('FM Radio',                         'KEY_FM_RADIO'),
+        ('DVI',                              'KEY_DVI'),
+        ('DVR',                              'KEY_DVR'),
+        ('TV',                               'KEY_TV'),
+        ('Analog TV',                        'KEY_ANTENA'),
+        ('Digital TV',                       'KEY_DTV')
+    )),
+    ('Number Keys ', (
+        ('Key1',                             'KEY_1'),
+        ('Key2',                             'KEY_2'),
+        ('Key3',                             'KEY_3'),
+        ('Key4',                             'KEY_4'),
+        ('Key5',                             'KEY_5'),
+        ('Key6',                             'KEY_6'),
+        ('Key7',                             'KEY_7'),
+        ('Key8',                             'KEY_8'),
+        ('Key9',                             'KEY_9'),
+        ('Key0',                             'KEY_0')
+    )),
+    ('Misc Keys ', (
+        ('3D',                               'KEY_PANNEL_CHDOWN'),
+        ('AnyNet+',                          'KEY_ANYNET'),
+        ('Energy Saving',                    'KEY_ESAVING'),
+        ('Sleep Timer',                      'KEY_SLEEP'),
+        ('DTV Signal',                       'KEY_DTV_SIGNAL')
+    )),
+    ('Channel Keys ', (
+        ('Channel Up',                       'KEY_CHUP'),
+        ('Channel Down',                     'KEY_CHDOWN'),
+        ('Previous Channel',                 'KEY_PRECH'),
+        ('Favorite Channels',                'KEY_FAVCH'),
+        ('Channel List',                     'KEY_CH_LIST'),
+        ('Auto Program',                     'KEY_AUTO_PROGRAM'),
+        ('Magic Channel',                    'KEY_MAGIC_CHANNEL'),
+    )),
+    ('Volume Keys ', (
+        ('Volume Up',                        'KEY_VOLUP'),
+        ('Volume Down',                      'KEY_VOLDOWN'),
+        ('Mute',                             'KEY_MUTE')
+    )),
+    ('Direction Keys ', (
+        ('Navigation Up',                    'KEY_UP'),
+        ('Navigation Down',                  'KEY_DOWN'),
+        ('Navigation Left',                  'KEY_LEFT'),
+        ('Navigation Right',                 'KEY_RIGHT'),
+        ('Navigation Return/Back',           'KEY_RETURN'),
+        ('Navigation Enter',                 'KEY_ENTER')
+    )),
+    ('Media Keys ', (
+        ('Rewind',                           'KEY_REWIND'),
+        ('Stop',                             'KEY_STOP'),
+        ('Play',                             'KEY_PLAY'),
+        ('Fast Forward',                     'KEY_FF'),
+        ('Record',                           'KEY_REC'),
+        ('Pause',                            'KEY_PAUSE'),
+        ('Live',                             'KEY_LIVE'),
+        ('fnKEY_QUICK_REPLAY',               'KEY_QUICK_REPLAY'),
+        ('fnKEY_STILL_PICTURE',              'KEY_STILL_PICTURE'),
+        ('fnKEY_INSTANT_REPLAY',             'KEY_INSTANT_REPLAY')
+    )),
+    ('Picture in Picture ', (
+        ('PIP On/Off',                       'KEY_PIP_ONOFF'),
+        ('PIP Swap',                         'KEY_PIP_SWAP'),
+        ('PIP Size',                         'KEY_PIP_SIZE'),
+        ('PIP Channel Up',                   'KEY_PIP_CHUP'),
+        ('PIP Channel Down',                 'KEY_PIP_CHDOWN'),
+        ('PIP Small',                        'KEY_AUTO_ARC_PIP_SMALL'),
+        ('PIP Wide',                         'KEY_AUTO_ARC_PIP_WIDE'),
+        ('PIP Bottom Right',                 'KEY_AUTO_ARC_PIP_RIGHT_BOTTOM'),
+        ('PIP Source Change',                'KEY_AUTO_ARC_PIP_SOURCE_CHANGE'),
+        ('PIP Scan',                         'KEY_PIP_SCAN')
+    )),
+    ('Modes ', (
+        ('VCR Mode',                         'KEY_VCR_MODE'),
+        ('CATV Mode',                        'KEY_CATV_MODE'),
+        ('DSS Mode',                         'KEY_DSS_MODE'),
+        ('TV Mode',                          'KEY_TV_MODE'),
+        ('DVD Mode',                         'KEY_DVD_MODE'),
+        ('STB Mode',                         'KEY_STB_MODE'),
+        ('PC Mode',                          'KEY_PCMODE')
+    )),
+    ('Color Keys ', (
+        ('Green',                            'KEY_GREEN'),
+        ('Yellow',                           'KEY_YELLOW'),
+        ('Cyan',                             'KEY_CYAN'),
+        ('Red',                              'KEY_RED')
+    )),
+    ('Teletext ', (
+        ('Teletext Mix',                     'KEY_TTX_MIX'),
+        ('Teletext Subface',                 'KEY_TTX_SUBFACE')
+    )),
+    ('Aspect Ratio ', (
+        ('Aspect Ratio',                     'KEY_ASPECT'),
+        ('Picture Size',                     'KEY_PICTURE_SIZE'),
+        ('Aspect Ratio 4:3',                 'KEY_4_3'),
+        ('Aspect Ratio 16:9',                'KEY_16_9'),
+        ('Aspect Ratio 3:4 (Alt)',           'KEY_EXT14'),
+        ('Aspect Ratio 16:9 (Alt)',          'KEY_EXT15')
+    )),
+    ('Picture Mode ', (
+        ('Picture Mode',                     'KEY_PMODE'),
+        ('Picture Mode Panorama',            'KEY_PANORAMA'),
+        ('Picture Mode Dynamic',             'KEY_DYNAMIC'),
+        ('Picture Mode Standard',            'KEY_STANDARD'),
+        ('Picture Mode Movie',               'KEY_MOVIE1'),
+        ('Picture Mode Game',                'KEY_GAME'),
+        ('Picture Mode Custom',              'KEY_CUSTOM'),
+        ('Picture Mode Movie (Alt)',         'KEY_EXT9'),
+        ('Picture Mode Standard (Alt)',      'KEY_EXT10')
+    )),
+    ('Menus ', (
+        ('Menu',                             'KEY_MENU'),
+        ('Top Menu',                         'KEY_TOPMENU'),
+        ('Tools',                            'KEY_TOOLS'),
+        ('Home',                             'KEY_HOME'),
+        ('Contents',                         'KEY_CONTENTS'),
+        ('Guide',                            'KEY_GUIDE'),
+        ('Disc Menu',                        'KEY_DISC_MENU'),
+        ('DVR Menu',                         'KEY_DVR_MENU'),
+        ('Help',                             'KEY_HELP')
+    )),
+    ('OSD ', (
+        ('Info',                             'KEY_INFO'),
+        ('Caption',                          'KEY_CAPTION'),
+        ('ClockDisplay',                     'KEY_CLOCK_DISPLAY'),
+        ('Setup Clock',                      'KEY_SETUP_CLOCK_TIMER'),
+        ('Subtitle',                         'KEY_SUB_TITLE'),
+    )),
+    ('Zoom ', (
+        ('Zoom Move',                        'KEY_ZOOM_MOVE'),
+        ('Zoom In',                          'KEY_ZOOM_IN'),
+        ('Zoom Out',                         'KEY_ZOOM_OUT'),
+        ('Zoom 1',                           'KEY_ZOOM1'),
+        ('Zoom 2',                           'KEY_ZOOM2')
+    )),
+    ('Other Keys ', (
+        ('Wheel Left',                       'KEY_WHEEL_LEFT'),
+        ('Wheel Right',                      'KEY_WHEEL_RIGHT'),
+        ('Add/Del',                          'KEY_ADDDEL'),
+        ('Plus 100',                         'KEY_PLUS100'),
+        ('AD',                               'KEY_AD'),
+        ('Link',                             'KEY_LINK'),
+        ('Turbo',                            'KEY_TURBO'),
+        ('Convergence',                      'KEY_CONVERGENCE'),
+        ('Device Connect',                   'KEY_DEVICE_CONNECT'),
+        ('Key 11',                           'KEY_11'),
+        ('Key 12',                           'KEY_12'),
+        ('Key Factory',                      'KEY_FACTORY'),
+        ('Key 3SPEED',                       'KEY_3SPEED'),
+        ('Key RSURF',                        'KEY_RSURF'),
+        ('FF_',                              'KEY_FF_'),
+        ('REWIND_',                          'KEY_REWIND_'),
+        ('Angle',                            'KEY_ANGLE'),
+        ('Reserved 1',                       'KEY_RESERVED1'),
+        ('Program',                          'KEY_PROGRAM'),
+        ('Bookmark',                         'KEY_BOOKMARK'),
+        ('Print',                            'KEY_PRINT'),
+        ('Clear',                            'KEY_CLEAR'),
+        ('V Chip',                           'KEY_VCHIP'),
+        ('Repeat',                           'KEY_REPEAT'),
+        ('Door',                             'KEY_DOOR'),
+        ('Open',                             'KEY_OPEN'),
+        ('DMA',                              'KEY_DMA'),
+        ('MTS',                              'KEY_MTS'),
+        ('DNIe',                             'KEY_DNIe'),
+        ('SRS',                              'KEY_SRS'),
+        ('Convert Audio Main/Sub',           'KEY_CONVERT_AUDIO_MAINSUB'),
+        ('MDC',                              'KEY_MDC'),
+        ('Sound Effect',                     'KEY_SEFFECT'),
+        ('PERPECT Focus',                    'KEY_PERPECT_FOCUS'),
+        ('Caller ID',                        'KEY_CALLER_ID'),
+        ('Scale',                            'KEY_SCALE'),
+        ('Magic Bright',                     'KEY_MAGIC_BRIGHT'),
+        ('W Link',                           'KEY_W_LINK'),
+        ('DTV Link',                         'KEY_DTV_LINK'),
+        ('Application List',                 'KEY_APP_LIST'),
+        ('Back MHP',                         'KEY_BACK_MHP'),
+        ('Alternate MHP',                    'KEY_ALT_MHP'),
+        ('DNSe',                             'KEY_DNSe'),
+        ('RSS',                              'KEY_RSS'),
+        ('Entertainment',                    'KEY_ENTERTAINMENT'),
+        ('ID Input',                         'KEY_ID_INPUT'),
+        ('ID Setup',                         'KEY_ID_SETUP'),
+        ('Any View',                         'KEY_ANYVIEW'),
+        ('MS',                               'KEY_MS'),
+        ('KEY_MORE',                         'KEY_MORE'),
+        ('KEY_MIC',                          'KEY_MIC'),
+        ('KEY_NINE_SEPERATE',                'KEY_NINE_SEPERATE'),
+        ('Auto Format',                      'KEY_AUTO_FORMAT'),
+        ('DNET',                             'KEY_DNET')
+    )),
+    ('Auto Arc Keys ', (
+        ('KEY_AUTO_ARC_C_FORCE_AGING',       'KEY_AUTO_ARC_C_FORCE_AGING'),
+        ('KEY_AUTO_ARC_CAPTION_ENG',         'KEY_AUTO_ARC_CAPTION_ENG'),
+        ('KEY_AUTO_ARC_USBJACK_INSPECT',     'KEY_AUTO_ARC_USBJACK_INSPECT'),
+        ('KEY_AUTO_ARC_RESET',               'KEY_AUTO_ARC_RESET'),
+        ('KEY_AUTO_ARC_LNA_ON',              'KEY_AUTO_ARC_LNA_ON'),
+        ('KEY_AUTO_ARC_LNA_OFF',             'KEY_AUTO_ARC_LNA_OFF'),
+        ('KEY_AUTO_ARC_ANYNET_MODE_OK',      'KEY_AUTO_ARC_ANYNET_MODE_OK'),
+        ('KEY_AUTO_ARC_ANYNET_AUTO_START',   'KEY_AUTO_ARC_ANYNET_AUTO_START'),
+        ('KEY_AUTO_ARC_CAPTION_ON',          'KEY_AUTO_ARC_CAPTION_ON'),
+        ('KEY_AUTO_ARC_CAPTION_OFF',         'KEY_AUTO_ARC_CAPTION_OFF'),
+        ('KEY_AUTO_ARC_PIP_DOUBLE',          'KEY_AUTO_ARC_PIP_DOUBLE'),
+        ('KEY_AUTO_ARC_PIP_LARGE',           'KEY_AUTO_ARC_PIP_LARGE'),
+        ('KEY_AUTO_ARC_PIP_LEFT_TOP',        'KEY_AUTO_ARC_PIP_LEFT_TOP'),
+        ('KEY_AUTO_ARC_PIP_RIGHT_TOP',       'KEY_AUTO_ARC_PIP_RIGHT_TOP'),
+        ('KEY_AUTO_ARC_PIP_LEFT_BOTTOM',     'KEY_AUTO_ARC_PIP_LEFT_BOTTOM'),
+        ('KEY_AUTO_ARC_PIP_CH_CHANGE',       'KEY_AUTO_ARC_PIP_CH_CHANGE'),
+        ('KEY_AUTO_ARC_AUTOCOLOR_SUCCESS',   'KEY_AUTO_ARC_AUTOCOLOR_SUCCESS'),
+        ('KEY_AUTO_ARC_AUTOCOLOR_FAIL',      'KEY_AUTO_ARC_AUTOCOLOR_FAIL'),
+        ('KEY_AUTO_ARC_JACK_IDENT',          'KEY_AUTO_ARC_JACK_IDENT'),
+        ('KEY_AUTO_ARC_CAPTION_KOR',         'KEY_AUTO_ARC_CAPTION_KOR'),
+        ('KEY_AUTO_ARC_ANTENNA_AIR',         'KEY_AUTO_ARC_ANTENNA_AIR'),
+        ('KEY_AUTO_ARC_ANTENNA_CABLE',       'KEY_AUTO_ARC_ANTENNA_CABLE'),
+        ('KEY_AUTO_ARC_ANTENNA_SATELLITE',   'KEY_AUTO_ARC_ANTENNA_SATELLITE'),
+    )),
+    ('Panel Keys ', (
+        ('KEY_PANNEL_POWER',                 'KEY_PANNEL_POWER'),
+        ('KEY_PANNEL_CHUP',                  'KEY_PANNEL_CHUP'),
+        ('KEY_PANNEL_VOLUP',                 'KEY_PANNEL_VOLUP'),
+        ('KEY_PANNEL_VOLDOW',                'KEY_PANNEL_VOLDOW'),
+        ('KEY_PANNEL_ENTER',                 'KEY_PANNEL_ENTER'),
+        ('KEY_PANNEL_MENU',                  'KEY_PANNEL_MENU'),
+        ('KEY_PANNEL_SOURCE',                'KEY_PANNEL_SOURCE'),
+        ('KEY_PANNEL_ENTER',                 'KEY_PANNEL_ENTER')
+    )),
+    ('Extended Keys ', (
+        ('KEY_EXT1',                         'KEY_EXT1'),
+        ('KEY_EXT2',                         'KEY_EXT2'),
+        ('KEY_EXT3',                         'KEY_EXT3'),
+        ('KEY_EXT4',                         'KEY_EXT4'),
+        ('KEY_EXT5',                         'KEY_EXT5'),
+        ('KEY_EXT6',                         'KEY_EXT6'),
+        ('KEY_EXT7',                         'KEY_EXT7'),
+        ('KEY_EXT8',                         'KEY_EXT8'),
+        ('KEY_EXT11',                        'KEY_EXT11'),
+        ('KEY_EXT12',                        'KEY_EXT12'),
+        ('KEY_EXT13',                        'KEY_EXT13'),
+        ('KEY_EXT16',                        'KEY_EXT16'),
+        ('KEY_EXT17',                        'KEY_EXT17'),
+        ('KEY_EXT18',                        'KEY_EXT18'),
+        ('KEY_EXT19',                        'KEY_EXT19'),
+        ('KEY_EXT20',                        'KEY_EXT20'),
+        ('KEY_EXT21',                        'KEY_EXT21'),
+        ('KEY_EXT22',                        'KEY_EXT22'),
+        ('KEY_EXT23',                        'KEY_EXT23'),
+        ('KEY_EXT24',                        'KEY_EXT24'),
+        ('KEY_EXT25',                        'KEY_EXT25'),
+        ('KEY_EXT26',                        'KEY_EXT26'),
+        ('KEY_EXT27',                        'KEY_EXT27'),
+        ('KEY_EXT28',                        'KEY_EXT28'),
+        ('KEY_EXT29',                        'KEY_EXT29'),
+        ('KEY_EXT30',                        'KEY_EXT30'),
+        ('KEY_EXT31',                        'KEY_EXT31'),
+        ('KEY_EXT32',                        'KEY_EXT32'),
+        ('KEY_EXT33',                        'KEY_EXT33'),
+        ('KEY_EXT34',                        'KEY_EXT34'),
+        ('KEY_EXT35',                        'KEY_EXT35'),
+        ('KEY_EXT36',                        'KEY_EXT36'),
+        ('KEY_EXT37',                        'KEY_EXT37'),
+        ('KEY_EXT38',                        'KEY_EXT38'),
+        ('KEY_EXT39',                        'KEY_EXT39'),
+        ('KEY_EXT40',                        'KEY_EXT40'),
+        ('KEY_EXT41',                        'KEY_EXT41')
+    ))
+)
+
+KEYS = {}
+
+for grp in KEY_MAPPINGS:
+    for k in grp[1]:
+        desc, cmd = k
+        KEYS[cmd] = SendButtonCls(cmd, grp[0], desc)


### PR DESCRIPTION
Adds more remote keys. support for different keys depends on the TV.
I also extended the interactive mode to include discrete inputs the
mappings are as follows.

    F1 - TV Source
    F2 - HDMI Source
    F3 - DVI Source
    F4 - DVR Source
    F5 - Digital TV Source
    F6 - Analog TV Source
    F7 - FM Radio Source
    F9 HDMI - 1 Source
    F10 HDMI - 2 Source
    F11 HDMI - 3 Source
    F12 HDMI - 4 Source
    CTRL+F1 - AV 1 Source
    CTRL+F2 - AV 2 Source
    CTRL+F3 - AV 3 Source
    CTRL+F5 - S Video 1 Source
    CTRL+F6 - S Video 2 Source
    CTRL+F7 - S Video 3 Source
    CTRL+F9 - Component 1 Source
    CTRL+F10 - Component 2 Source

I added the command line arg --key-help to the argument parser. I
supplied a default value to the positional key arguments. This is done
so that if --key-help is used and no positional arguments are passed
it will print off a full list of available keys. if keys are passed
it will print off a help for that key

basically the key help for a single key is to show the description of
that key. because there are keys that do not map out to what they
actually do. In the event someone forgets what a specific key command is
for.

Because I am running on Windows I added support for config file saving
and loading. as this threw an error when i ran the script.
I also did a little reorganization of the config file loading. this way
done when i was trying to track down the problem mentioned above. I
also added \_\_future\_\_.print_function for python 2 compatibility when
printing the help for the keys. The printing of the keys gets done before
a config file gets loaded. this is so that in the event the user has not
set up a config file yet the --key-help will still run.

I also added .idea to gitignore .idea is to exclude the project files from pycharm