### PR TITLE
Add notice about `windows-curses`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Dependencies
 
 - Python 3
 - ``websocket-client`` (optional, for 2016+ TVs)
-- ``curses`` (optional, for the interactive mode)
+- ``curses`` or ``windows-curses`` (optional, for the interactive mode)
 
 Installation
 ============


### PR DESCRIPTION
I added notice about `windows-curses` in dependencies.

`windows-curses` adds support for the standard Python curses module on Windows. Based on https://www.lfd.uci.edu/~gohlke/pythonlibs/#curses. Uses the PDCurses curses implementation.